### PR TITLE
Feature: Integrating Event Type Data into Scheduler View

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -7824,6 +7824,11 @@
         "istanbul-lib-report": "^3.0.0"
       }
     },
+    "jalaali-js": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/jalaali-js/-/jalaali-js-1.1.5.tgz",
+      "integrity": "sha512-eS+zDRtz2JcGnVPWeng53rzlKU8tX2RWbJ1cqu1+eZHPEh1QL5ydB+pXD4RCf/zE3eKDN2bLQEjY0u/WIewMVQ=="
+    },
     "jest": {
       "version": "26.6.0",
       "resolved": "https://registry.npmjs.org/jest/-/jest-26.6.0.tgz",
@@ -11885,6 +11890,14 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+    },
+    "react-modern-calendar-datepicker": {
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/react-modern-calendar-datepicker/-/react-modern-calendar-datepicker-3.1.6.tgz",
+      "integrity": "sha512-lnMqEMj9Wn32/sm119tjCl5lOkq4u9vJE7wggi7hdXV4s8rPdKlH56FVVehlBi0dfYeWQVZ9npY384Zprjn4WA==",
+      "requires": {
+        "jalaali-js": "^1.1.0"
+      }
     },
     "react-refresh": {
       "version": "0.8.3",

--- a/client/package.json
+++ b/client/package.json
@@ -12,6 +12,7 @@
     "http-proxy-middleware": "^1.0.6",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
+    "react-modern-calendar-datepicker": "^3.1.6",
     "react-router-dom": "^5.2.0",
     "react-scripts": "4.0.0",
     "web-vitals": "^0.2.4"

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -34,7 +34,9 @@ function App () {
           <Route path="/login" component={LogIn} />
           <Route path="/googleSignUp" component={SignUpGoogle} email={email} />
           <Route exact path="/" component={SignUpEmail} handleEmailEntry={handleEmailEntry} />
-          <Route path="/calendar" component={Scheduler} />
+          <UserProvider>
+            <Route path="/calendar" component={Scheduler} />
+          </UserProvider>
           <Fragment>
             <UserProvider>
               <Header />

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -35,7 +35,7 @@ function App ({ location }) {
           <Route path="/login" component={LogIn} />
           <Route path="/googleSignUp" component={SignUpGoogle} email={email} />
           <Route exact path="/" component={SignUpEmail} handleEmailEntry={handleEmailEntry} />
-          <Route path="/calendar" component={Scheduler} />  
+          <Route path="/scheduler/:user/:event_type" component={Scheduler} />  
           <Fragment>
             <Header/>
             <UserProvider>

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -17,6 +17,9 @@ import EventTypes from "./pages/dashboard/EventTypes";
 import NewEventType from "./pages/dashboard/NewEventType";
 import ScheduledEvents from "./pages/dashboard/ScheduledEvents";
 
+// Scheduler
+import Scheduler from "./pages/scheduling/Scheduler";
+
 function App () {
   const [email, setEmail] = useState("");
 
@@ -31,6 +34,7 @@ function App () {
           <Route path="/login" component={LogIn} />
           <Route path="/googleSignUp" component={SignUpGoogle} email={email} />
           <Route exact path="/" component={SignUpEmail} handleEmailEntry={handleEmailEntry} />
+          <Route path="/calendar" component={Scheduler} />
           <Fragment>
             <UserProvider>
               <Header />

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -20,7 +20,8 @@ import ScheduledEvents from "./pages/dashboard/ScheduledEvents";
 // Scheduler
 import Scheduler from "./pages/scheduling/Scheduler";
 
-function App () {
+
+function App ({ location }) {
   const [email, setEmail] = useState("");
 
   const handleEmailEntry = (e) => {
@@ -34,12 +35,10 @@ function App () {
           <Route path="/login" component={LogIn} />
           <Route path="/googleSignUp" component={SignUpGoogle} email={email} />
           <Route exact path="/" component={SignUpEmail} handleEmailEntry={handleEmailEntry} />
-          <UserProvider>
-            <Route path="/calendar" component={Scheduler} />
-          </UserProvider>
+          <Route path="/calendar" component={Scheduler} />  
           <Fragment>
+            <Header/>
             <UserProvider>
-              <Header />
               <Route path="/profile" component={Profile} />
               <Route path="/event_types/new" component={NewEventType} />
               <Route path="/event_types/user/me" component={EventTypes} />

--- a/client/src/components/DataDisplay/EventTypeCard.js
+++ b/client/src/components/DataDisplay/EventTypeCard.js
@@ -74,14 +74,7 @@ export default function EventTypeCard (props) {
                 <Link 
                   to={
                     {
-                      pathname: `/scheduler/${firstName.toLowerCase()}-${lastName.toLowerCase()}/${id}`,
-                      schedulerProps: {
-                        firstName,
-                        lastName,
-                        id, 
-                        name, 
-                        duration
-                      }                     
+                      pathname: `/scheduler/${firstName.toLowerCase()}-${lastName.toLowerCase()}/${id}`,              
                     }
                   }
                 >

--- a/client/src/components/DataDisplay/EventTypeCard.js
+++ b/client/src/components/DataDisplay/EventTypeCard.js
@@ -74,7 +74,7 @@ export default function EventTypeCard (props) {
                 <Link 
                   to={
                     {
-                      pathname: "/calendar",
+                      pathname: `/scheduler/${firstName.toLowerCase()}-${lastName.toLowerCase()}/${id}`,
                       schedulerProps: {
                         firstName,
                         lastName,

--- a/client/src/components/DataDisplay/EventTypeCard.js
+++ b/client/src/components/DataDisplay/EventTypeCard.js
@@ -1,6 +1,17 @@
 /* eslint react/prop-types: 0 */
 import React from "react";
-import { Card, CardActions, CardContent, Typography, Divider, Button, Grid, IconButton, Box } from "@material-ui/core";
+import { Link } from "react-router-dom";
+import { 
+  Card,
+  CardActions,
+  CardContent, 
+  Typography, 
+  Divider, 
+  Button, 
+  Grid, 
+  IconButton, 
+  Box 
+} from "@material-ui/core";
 import { makeStyles } from "@material-ui/core/styles";
 import { Settings, Timer } from "@material-ui/icons";
 
@@ -21,9 +32,14 @@ const useStyles = makeStyles({
   }
 });
 
-export default function EventTypeCard ({ name, duration }) {
+export default function EventTypeCard (props) {
   const classes = useStyles();
-
+  const { 
+    firstName,
+    lastName,
+    id, 
+    name, 
+    duration } = props;
   return (
     <Box borderTop={5} borderColor="primary.main" borderRadius="borderRadius">
       <Card className={classes.root}>
@@ -41,16 +57,38 @@ export default function EventTypeCard ({ name, duration }) {
           <Typography className={classes.pos} color="textSecondary">
             One-on-One
           </Typography>
+          <Grid container justify="flex-start" alignItems="center" item xs={6} spacing={1}>
+              <Grid item>
+                <Timer />
+              </Grid>
+              <Grid item>
+                <Typography variant="subtitle2">{duration} min</Typography>
+              </Grid>
+            </Grid>
         </CardContent>
         <Divider/>
         <CardActions>
           <Grid container justify="space-between">
             <Grid container justify="flex-start" alignItems="center" item xs={6} spacing={1}>
               <Grid item>
-                <Timer />
-              </Grid>
-              <Grid item>
-                <Typography variant="subtitle2">{duration} min</Typography>
+                <Link 
+                  to={
+                    {
+                      pathname: "/calendar",
+                      schedulerProps: {
+                        firstName,
+                        lastName,
+                        id, 
+                        name, 
+                        duration
+                      }                     
+                    }
+                  }
+                >
+                  <Typography variant="subtitle2">
+                    /{id.substring(0,8)}...
+                  </Typography>
+                </Link>
               </Grid>
             </Grid>
             <Grid container justify="flex-end" item xs={6}>

--- a/client/src/pages/dashboard/EventTypes.js
+++ b/client/src/pages/dashboard/EventTypes.js
@@ -34,13 +34,14 @@ const EventTypes = () => {
   const theme = useTheme();
   const matches = useMediaQuery(theme.breakpoints.up("md"));
 
-  const userData = useContext(UserProvider.context);
+  const userContext = useContext(UserProvider.context);
+  const currentUser = userContext.user.user;
   
   return (
     <>
       <DashboardHeader />
       {
-        userData.user.user && (
+        currentUser && (
           <Container >
           <div className={classes.root}>
             <Grid container alignContent="center" justify="space-between" spacing={1}>
@@ -51,10 +52,10 @@ const EventTypes = () => {
                 </Grid>
                 <Grid container direction="column" item xs={11}>
                   <Grid item>
-                    <Typography>{userData.user.user.firstName} {userData.user.user.lastName}</Typography>
+                    <Typography>{currentUser.firstName} {currentUser.lastName}</Typography>
                   </Grid>
                   <Grid item>
-                    <Typography color="primary">calendly.com/{userData.user.user.firstName.toLowerCase()}-{userData.user.user.lastName.toLowerCase()}</Typography>
+                    <Typography color="primary">calendly.com/{currentUser.firstName.toLowerCase()}-{currentUser.lastName.toLowerCase()}</Typography>
                   </Grid>
                 </Grid>
               </Grid>
@@ -74,12 +75,12 @@ const EventTypes = () => {
             </Grid>
             <Divider className={classes.divider} />
             <Grid className={classes.eventTypes} container spacing={4} justify="flex-start">
-              {userData.user.user.meetingTypes.map(({ id, name, duration }) => (
+              {currentUser.meetingTypes.map(({ id, name, duration }) => (
                 <Grid key={id} item xs={12} md={4}>
                   <EventTypeCard 
                     id={id} 
-                    firstName={userData.user.user.firstName} 
-                    lastName={userData.user.user.lastName} 
+                    firstName={currentUser.firstName} 
+                    lastName={currentUser.lastName} 
                     name={name} 
                     duration={duration} 
                     />

--- a/client/src/pages/dashboard/EventTypes.js
+++ b/client/src/pages/dashboard/EventTypes.js
@@ -76,7 +76,13 @@ const EventTypes = () => {
             <Grid className={classes.eventTypes} container spacing={4} justify="flex-start">
               {userData.user.user.meetingTypes.map(({ id, name, duration }) => (
                 <Grid key={id} item xs={12} md={4}>
-                  <EventTypeCard name={name} duration={duration} />
+                  <EventTypeCard 
+                    id={id} 
+                    firstName={userData.user.user.firstName} 
+                    lastName={userData.user.user.lastName} 
+                    name={name} 
+                    duration={duration} 
+                    />
                 </Grid>
               ))}
             </Grid>

--- a/client/src/pages/dashboard/NewEventType.js
+++ b/client/src/pages/dashboard/NewEventType.js
@@ -23,7 +23,7 @@ const NewEventType = (props) => {
   //   Submit Form Data to Back-End
 
   const userContext = useContext(UserProvider.context);
-  console.log(userContext);
+  const currentUser = userContext.user.user;
 
   const [name, setName] = useState("");
   const [description, setDescription] = useState("");
@@ -40,7 +40,7 @@ const NewEventType = (props) => {
     event.preventDefault();
 
     const eventTypeData = {
-      userId: userContext.user.user.id,
+      userId: currentUser.id,
       name: name,
       description: description,
       duration: Number(duration)

--- a/client/src/pages/scheduling/Scheduler.js
+++ b/client/src/pages/scheduling/Scheduler.js
@@ -1,6 +1,6 @@
 import React from "react";
 import Container from "../../components/Layout/Container";
-import { Card, CardContent, Grid, Divider, Typography } from "@material-ui/core";
+import { Box, Grid, Divider, Typography } from "@material-ui/core";
 import { makeStyles } from "@material-ui/core/styles";
 import { Timer } from "@material-ui/icons";
 
@@ -18,24 +18,34 @@ const Scheduler = () => {
   const classes = useStyles();
   return (
     <Container>
-      <Card className={classes.root}>
-        <CardContent>
-          <Grid container spacing={2}>
-            <Grid item md={6}>
-              <Typography variant="subtitle1" gutterBottom>John Doe</Typography>
-              <Typography variant="h5" gutterBottom>Event Name</Typography>
-              <Grid container spacing={1} alignItems="center">
-                <Grid item>
-                  <Timer className={classes.timer} />
-                </Grid>
-                <Grid item>
-                  <Typography variant="subtitle2">60 min</Typography>
-                </Grid>
-              </Grid>
+      <Box p={1} border={1} borderRadius="borderRadius" borderColor="grey.500" className={classes.root}>
+      <Grid container spacing={2}>
+        <Grid item md={3} xs={12}>
+          <Typography variant="subtitle1" gutterBottom>John Doe</Typography>
+          <Typography variant="h5" gutterBottom>Event Name</Typography>
+          <Grid container spacing={1} alignItems="center">
+            <Grid item>
+              <Timer className={classes.timer} />
+            </Grid>
+            <Grid item>
+              <Typography variant="subtitle2">60 min</Typography>
+            </Grid>
             </Grid>
           </Grid>
-        </CardContent>
-      </Card>
+          <Divider orientation="vertical" flexItem />
+          <Grid container item md={9} xs={12} spacing={1}>
+            <Grid item md={12} xs={12}>
+              <Typography variant="h6" gutterBottom>Select a Date & Time</Typography>
+            </Grid>
+            <Grid item md={8} xs={12}>
+              <Typography>Calendar</Typography>
+            </Grid>
+            <Grid item md={4} xs={12}>
+              <Typography>Time Picker</Typography>
+            </Grid>
+          </Grid>
+        </Grid>
+      </Box>
     </Container>
   )
 }

--- a/client/src/pages/scheduling/Scheduler.js
+++ b/client/src/pages/scheduling/Scheduler.js
@@ -51,7 +51,9 @@ const Scheduler = (props) => {
       <Grid container justify="flex-end">
         <Grid container justify="flex-end" item xs={4}>
           <Button 
-            className={classes.nav} variant="outlined" component={Link} to="/event_types/user/me">Home</Button>
+            className={classes.nav} variant="outlined" 
+            // component={Link} 
+            href="http://localhost:3000/event_types/user/me">Home</Button>
         </Grid>
       </Grid>
       {eventType && 

--- a/client/src/pages/scheduling/Scheduler.js
+++ b/client/src/pages/scheduling/Scheduler.js
@@ -1,51 +1,80 @@
-import React from "react";
+import React, { useState } from "react";
 import Container from "../../components/Layout/Container";
-import { Box, Grid, Divider, Typography } from "@material-ui/core";
-import { makeStyles } from "@material-ui/core/styles";
+import { Box, Grid, Button, Divider, Typography, Paper, useMediaQuery } from "@material-ui/core";
+import { makeStyles, useTheme } from "@material-ui/core/styles";
 import { Timer } from "@material-ui/icons";
+
+import "react-modern-calendar-datepicker/lib/DatePicker.css";
+import { Calendar } from "react-modern-calendar-datepicker";
 
 
 const useStyles = makeStyles((theme) => ({
   root: {
     marginTop: theme.spacing(10)
   },
-  timer: {
-    fontsize: "5rem"
+  chosenDay: {
+    marginTop: theme.spacing(4)
+  },
+  timePicker: {
+    '& > *': {
+      marginTop: theme.spacing(3),
+    }
   }
 }));
 
 const Scheduler = () => {
+  const theme = useTheme();
+  const matches = useMediaQuery(theme.breakpoints.down("sm"));
+
   const classes = useStyles();
+  const [selectedDay, setSelectedDay] = useState(null);
+  console.log(selectedDay);
   return (
     <Container>
-      <Box p={1} border={1} borderRadius="borderRadius" borderColor="grey.500" className={classes.root}>
-      <Grid container spacing={2}>
-        <Grid item md={3} xs={12}>
-          <Typography variant="subtitle1" gutterBottom>John Doe</Typography>
-          <Typography variant="h5" gutterBottom>Event Name</Typography>
-          <Grid container spacing={1} alignItems="center">
-            <Grid item>
-              <Timer className={classes.timer} />
+      <Paper className={classes.root}>
+        <Box p={4}>
+          <Grid container spacing={2}>
+            <Grid item md={3} xs={12}>
+              <Typography variant="subtitle1" align={matches ? "center" : "inherit"} gutterBottom>John Doe</Typography>
+              <Typography variant="h5" align={matches ? "center" : "inherit"} gutterBottom>Event Name</Typography>
+              <Grid container spacing={1} alignItems="center" justify={matches ? "center" : "flex-start"}>
+                <Grid item>
+                  <Timer />
+                </Grid>
+                <Grid item>
+                  <Typography variant="subtitle2">60 min</Typography>
+                </Grid>
+              </Grid>
             </Grid>
-            <Grid item>
-              <Typography variant="subtitle2">60 min</Typography>
-            </Grid>
+            <Divider orientation={matches ? "horizontal" : "vertical"} flexItem={matches ? false : true} fullWidth />
+            <Grid container item md={9} xs={12} spacing={1} >
+              <Grid item md={12} xs={12}>
+                <Typography variant="h6" align={matches ? "center" : "inherit"} gutterBottom>Select a Date & Time</Typography>
+              </Grid>
+              <Grid container justify="center" item md={6} xs={12}>
+                <Calendar
+                  value={selectedDay}
+                  onChange={setSelectedDay}
+                  shouldHighlightWeekends
+                />
+              </Grid>
+              <Grid item md={6} xs={12}>
+                {selectedDay && 
+                <>
+                  <Typography className={classes.chosenDay} align="center">{selectedDay.month}/{selectedDay.day}/{selectedDay.year}</Typography>
+                  <div className={classes.timePicker}>
+                    <Button variant="outlined" size="large" color="primary" fullWidth >16:30</Button>
+                    <Button variant="outlined" size="large" color="primary" fullWidth >17:00</Button>
+                    <Button variant="outlined" size="large" color="primary" fullWidth >17:30</Button>
+                    <Button variant="outlined" size="large" color="primary" fullWidth >18:00</Button>
+                  </div>
+                </>
+                }
+              </Grid>
             </Grid>
           </Grid>
-          <Divider orientation="vertical" flexItem />
-          <Grid container item md={9} xs={12} spacing={1}>
-            <Grid item md={12} xs={12}>
-              <Typography variant="h6" gutterBottom>Select a Date & Time</Typography>
-            </Grid>
-            <Grid item md={8} xs={12}>
-              <Typography>Calendar</Typography>
-            </Grid>
-            <Grid item md={4} xs={12}>
-              <Typography>Time Picker</Typography>
-            </Grid>
-          </Grid>
-        </Grid>
-      </Box>
+        </Box>
+      </Paper>
     </Container>
   )
 }

--- a/client/src/pages/scheduling/Scheduler.js
+++ b/client/src/pages/scheduling/Scheduler.js
@@ -1,4 +1,5 @@
 import React, { useState } from "react";
+import { Link } from "react-router-dom";
 import Container from "../../components/Layout/Container";
 import { Box, Grid, Button, Divider, Typography, Paper, useMediaQuery } from "@material-ui/core";
 import { makeStyles, useTheme } from "@material-ui/core/styles";
@@ -10,7 +11,10 @@ import { Calendar } from "react-modern-calendar-datepicker";
 
 const useStyles = makeStyles((theme) => ({
   root: {
-    marginTop: theme.spacing(10)
+    marginTop: theme.spacing(5)
+  },
+  nav: {
+    marginTop: theme.spacing(2)
   },
   chosenDay: {
     marginTop: theme.spacing(4)
@@ -37,6 +41,12 @@ const Scheduler = (props) => {
   const [selectedDay, setSelectedDay] = useState(null);
   return (
     <Container>
+      <Grid container justify="flex-end">
+        <Grid container justify="flex-end" item xs={4}>
+          <Button 
+            className={classes.nav} variant="outlined" component={Link} to="/event_types/user/me">Home</Button>
+        </Grid>
+      </Grid>
       {props.location.schedulerProps && 
       <Paper className={classes.root}>
         <Box p={4}>

--- a/client/src/pages/scheduling/Scheduler.js
+++ b/client/src/pages/scheduling/Scheduler.js
@@ -1,5 +1,6 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import { Link } from "react-router-dom";
+import axios from "axios";
 import Container from "../../components/Layout/Container";
 import { Box, Grid, Button, Divider, Typography, Paper, useMediaQuery } from "@material-ui/core";
 import { makeStyles, useTheme } from "@material-ui/core/styles";
@@ -30,15 +31,21 @@ const Scheduler = (props) => {
   const theme = useTheme();
   const matches = useMediaQuery(theme.breakpoints.down("sm"));
 
-  const {
-    firstName,
-    lastName,
-    name,
-    duration
-  } = props.location.schedulerProps
+  // console.log(props.match.params.event_type);
+  const eventTypeID = props.match.params.event_type;
+
+  const [eventType, setEventType] = useState(null);
+
+  // Retrieve Event Type Information from params
+  useEffect(() => {
+    axios.get(`http://localhost:3001/api/meeting_types/single/${eventTypeID}`)
+      .then(response => setEventType(response.data));
+  }, []);
+
 
   const classes = useStyles();
   const [selectedDay, setSelectedDay] = useState(null);
+
   return (
     <Container>
       <Grid container justify="flex-end">
@@ -47,19 +54,19 @@ const Scheduler = (props) => {
             className={classes.nav} variant="outlined" component={Link} to="/event_types/user/me">Home</Button>
         </Grid>
       </Grid>
-      {props.location.schedulerProps && 
+      {eventType && 
       <Paper className={classes.root}>
         <Box p={4}>
           <Grid container spacing={2}>
             <Grid item md={3} xs={12}>
-              <Typography variant="subtitle1" align={matches ? "center" : "inherit"} gutterBottom>{firstName} {lastName}</Typography>
-              <Typography variant="h5" align={matches ? "center" : "inherit"} gutterBottom>{name}</Typography>
+              <Typography variant="subtitle1" align={matches ? "center" : "inherit"} gutterBottom>{eventType.user.firstName} {eventType.user.lastName}</Typography>
+              <Typography variant="h5" align={matches ? "center" : "inherit"} gutterBottom>{eventType.name}</Typography>
               <Grid container spacing={1} alignItems="center" justify={matches ? "center" : "flex-start"}>
                 <Grid item>
                   <Timer />
                 </Grid>
                 <Grid item>
-                  <Typography variant="subtitle2">{duration} min</Typography>
+                  <Typography variant="subtitle2">{eventType.duration} min</Typography>
                 </Grid>
               </Grid>
             </Grid>
@@ -93,7 +100,7 @@ const Scheduler = (props) => {
         </Box>
       </Paper>      
       }
-    </Container>
+    </Container> 
   )
 }
 

--- a/client/src/pages/scheduling/Scheduler.js
+++ b/client/src/pages/scheduling/Scheduler.js
@@ -1,5 +1,4 @@
-import React, { useContext, useState } from "react";
-import UserProvider from "../../contexts/UserProvider";
+import React, { useState } from "react";
 import Container from "../../components/Layout/Container";
 import { Box, Grid, Button, Divider, Typography, Paper, useMediaQuery } from "@material-ui/core";
 import { makeStyles, useTheme } from "@material-ui/core/styles";
@@ -23,32 +22,34 @@ const useStyles = makeStyles((theme) => ({
   }
 }));
 
-const Scheduler = () => {
+const Scheduler = (props) => {
   const theme = useTheme();
   const matches = useMediaQuery(theme.breakpoints.down("sm"));
 
-  const userContext = useContext(UserProvider.context);
-  console.log(userContext);
+  const {
+    firstName,
+    lastName,
+    name,
+    duration
+  } = props.location.schedulerProps
 
   const classes = useStyles();
   const [selectedDay, setSelectedDay] = useState(null);
-  console.log(selectedDay);
   return (
     <Container>
-      {
-        userContext.user.user &&
-        <Paper className={classes.root}>
+      {props.location.schedulerProps && 
+      <Paper className={classes.root}>
         <Box p={4}>
           <Grid container spacing={2}>
             <Grid item md={3} xs={12}>
-              <Typography variant="subtitle1" align={matches ? "center" : "inherit"} gutterBottom>{userContext.user.user.firstName} {userContext.user.user.lastName}</Typography>
-              <Typography variant="h5" align={matches ? "center" : "inherit"} gutterBottom>Event Name</Typography>
+              <Typography variant="subtitle1" align={matches ? "center" : "inherit"} gutterBottom>{firstName} {lastName}</Typography>
+              <Typography variant="h5" align={matches ? "center" : "inherit"} gutterBottom>{name}</Typography>
               <Grid container spacing={1} alignItems="center" justify={matches ? "center" : "flex-start"}>
                 <Grid item>
                   <Timer />
                 </Grid>
                 <Grid item>
-                  <Typography variant="subtitle2">60 min</Typography>
+                  <Typography variant="subtitle2">{duration} min</Typography>
                 </Grid>
               </Grid>
             </Grid>
@@ -80,9 +81,8 @@ const Scheduler = () => {
             </Grid>
           </Grid>
         </Box>
-      </Paper>
+      </Paper>      
       }
-      
     </Container>
   )
 }

--- a/client/src/pages/scheduling/Scheduler.js
+++ b/client/src/pages/scheduling/Scheduler.js
@@ -1,4 +1,5 @@
-import React, { useState } from "react";
+import React, { useContext, useState } from "react";
+import UserProvider from "../../contexts/UserProvider";
 import Container from "../../components/Layout/Container";
 import { Box, Grid, Button, Divider, Typography, Paper, useMediaQuery } from "@material-ui/core";
 import { makeStyles, useTheme } from "@material-ui/core/styles";
@@ -26,16 +27,21 @@ const Scheduler = () => {
   const theme = useTheme();
   const matches = useMediaQuery(theme.breakpoints.down("sm"));
 
+  const userContext = useContext(UserProvider.context);
+  console.log(userContext);
+
   const classes = useStyles();
   const [selectedDay, setSelectedDay] = useState(null);
   console.log(selectedDay);
   return (
     <Container>
-      <Paper className={classes.root}>
+      {
+        userContext.user.user &&
+        <Paper className={classes.root}>
         <Box p={4}>
           <Grid container spacing={2}>
             <Grid item md={3} xs={12}>
-              <Typography variant="subtitle1" align={matches ? "center" : "inherit"} gutterBottom>John Doe</Typography>
+              <Typography variant="subtitle1" align={matches ? "center" : "inherit"} gutterBottom>{userContext.user.user.firstName} {userContext.user.user.lastName}</Typography>
               <Typography variant="h5" align={matches ? "center" : "inherit"} gutterBottom>Event Name</Typography>
               <Grid container spacing={1} alignItems="center" justify={matches ? "center" : "flex-start"}>
                 <Grid item>
@@ -75,6 +81,8 @@ const Scheduler = () => {
           </Grid>
         </Box>
       </Paper>
+      }
+      
     </Container>
   )
 }

--- a/client/src/pages/scheduling/Scheduler.js
+++ b/client/src/pages/scheduling/Scheduler.js
@@ -1,0 +1,43 @@
+import React from "react";
+import Container from "../../components/Layout/Container";
+import { Card, CardContent, Grid, Divider, Typography } from "@material-ui/core";
+import { makeStyles } from "@material-ui/core/styles";
+import { Timer } from "@material-ui/icons";
+
+
+const useStyles = makeStyles((theme) => ({
+  root: {
+    marginTop: theme.spacing(10)
+  },
+  timer: {
+    fontsize: "5rem"
+  }
+}));
+
+const Scheduler = () => {
+  const classes = useStyles();
+  return (
+    <Container>
+      <Card className={classes.root}>
+        <CardContent>
+          <Grid container spacing={2}>
+            <Grid item md={6}>
+              <Typography variant="subtitle1" gutterBottom>John Doe</Typography>
+              <Typography variant="h5" gutterBottom>Event Name</Typography>
+              <Grid container spacing={1} alignItems="center">
+                <Grid item>
+                  <Timer className={classes.timer} />
+                </Grid>
+                <Grid item>
+                  <Typography variant="subtitle2">60 min</Typography>
+                </Grid>
+              </Grid>
+            </Grid>
+          </Grid>
+        </CardContent>
+      </Card>
+    </Container>
+  )
+}
+
+export default Scheduler;

--- a/client/src/pages/scheduling/Scheduler.js
+++ b/client/src/pages/scheduling/Scheduler.js
@@ -61,7 +61,7 @@ const Scheduler = () => {
               <Grid item md={6} xs={12}>
                 {selectedDay && 
                 <>
-                  <Typography className={classes.chosenDay} align="center">{selectedDay.month}/{selectedDay.day}/{selectedDay.year}</Typography>
+                  <Typography className={classes.chosenDay} align="center">{new Date(selectedDay.year, selectedDay.month - 1, selectedDay.day).toLocaleString("default", { month: "long" })} {selectedDay.day}, {selectedDay.year}</Typography>
                   <div className={classes.timePicker}>
                     <Button variant="outlined" size="large" color="primary" fullWidth >16:30</Button>
                     <Button variant="outlined" size="large" color="primary" fullWidth >17:00</Button>

--- a/server/controllers/auth.js
+++ b/server/controllers/auth.js
@@ -4,7 +4,7 @@ const authRouter = require("express").Router();
 
 // @desc Auth with Google
 // @route GET / 
-authRouter.get("/google", passport.authenticate("google", { scope: ["profile", "email"] }));
+authRouter.get("/google", passport.authenticate("google", { scope: ["profile", "email", "https://www.googleapis.com/auth/calendar.readonly"] }));
 
 // @desc Google Auth Callback
 // @route GET /auth/google/callback

--- a/server/controllers/meetingType.js
+++ b/server/controllers/meetingType.js
@@ -35,7 +35,7 @@ meetingTypesRouter.get("/", async (request, response) => {
 
 // @desc Fetch/Read All meetings by User ID
 // @route GET /
-meetingTypesRouter.get("/:userID", async (request, response) => { 
+meetingTypesRouter.get("/user/:userID", async (request, response) => { 
     const meetingTypes = await MeetingType.find({ user:request.params.userID });
     response.json(meetingTypes);
 });
@@ -43,8 +43,12 @@ meetingTypesRouter.get("/:userID", async (request, response) => {
 
 // @desc Fetch/Read Single meeting
 // @route GET /
-meetingTypesRouter.get("/:id", async (request, response) => {
-    const meetingTypes = await MeetingType.findById(request.params.id);
+meetingTypesRouter.get("/single/:id", async (request, response) => {
+    const meetingTypes = await MeetingType.findById(request.params.id)
+        .populate("user", {
+            firstName: 1,
+            lastName: 1
+        });
     response.json(meetingTypes);
 });
 

--- a/server/requests/meetingType/get_single_meeting_type.rest
+++ b/server/requests/meetingType/get_single_meeting_type.rest
@@ -1,0 +1,1 @@
+GET http://localhost:3001/api/meeting_types/single/5fc121f16f9898142d703363


### PR DESCRIPTION
### What it does:
* click link on card to go to scheduler page (generates dynamic url based off user-name and event type id)
![image](https://user-images.githubusercontent.com/28552357/101293022-1f771800-37e1-11eb-8774-5f960fab7343.png)
* scheduler page renders with event type information fetched from back-end controller using event-type id
![image](https://user-images.githubusercontent.com/28552357/101293058-42a1c780-37e1-11eb-969d-380bc5950d5e.png)

### What to Look For:
* correct implementation of pulling back-end data to front-end

### What to Avoid:
* currently there is a bug with the calendar package that I've imported where if I click the "Home" to go back to the dashboard, I get a `TypeError: T.current is null`:
![image](https://user-images.githubusercontent.com/28552357/101293202-aa581280-37e1-11eb-9f0c-6e3b27b2a36a.png)
* looking through the [calendar repo ](https://github.com/Kiarash-Z/react-modern-calendar-datepicker/issues?q=is%3Aissue+null+is%3Aclosed)for similar issues, but not able to find anything so far