### PR TITLE
Render Availabilities as TimeSlots in Scheduler View from FreeBusy API

### DIFF
--- a/client/src/pages/scheduling/Scheduler.js
+++ b/client/src/pages/scheduling/Scheduler.js
@@ -44,18 +44,23 @@ const Scheduler = (props) => {
       .then(response => setEventType(response.data));
   }, []);
 
+  const todaysDate = new Date();
+  const tomorrowsDate = new Date(todaysDate);
+  tomorrowsDate.setDate(tomorrowsDate.getDate() + 1);
 
   const classes = useStyles();
-  const [selectedDay, setSelectedDay] = useState(null);
+  const [selectedDay, setSelectedDay] = useState({
+    day: tomorrowsDate.getDate(),
+    month: tomorrowsDate.getMonth() + 1,
+    year: tomorrowsDate.getFullYear()
+  });
   const [avail, setAvail] = useState([]);
 
   const handleDaySelection = async (props) => {
-    console.log(props);
     setSelectedDay(props);
     const { day, month, year } = props;
     await axios.get(`http://localhost:3001/api/avail/freebusy?user=${eventType.user.id}&day=${day}&month=${month - 1}&year=${year}&duration=${eventType.duration}`)
       .then(response => setAvail(response.data));
-    console.log(avail);
   };
 
   return (

--- a/client/src/pages/scheduling/Scheduler.js
+++ b/client/src/pages/scheduling/Scheduler.js
@@ -20,6 +20,8 @@ const useStyles = makeStyles((theme) => ({
     marginTop: theme.spacing(4)
   },
   timePicker: {
+    height: "300px",
+    overflowY: "auto",
     '& > *': {
       marginTop: theme.spacing(3),
     }

--- a/server/controllers/availability.js
+++ b/server/controllers/availability.js
@@ -4,9 +4,11 @@ const { google } = require("googleapis");
 
 // @desc FreeBusy
 // @route GET /freebusy?date=143213434&meetingTypeID=df34234fgdg235
-availabilitiesRouter.get("/freebusy", (request, response) => {
-    // request.query.meetingTypeID
-    // request.query.date // must be in datetime format
+availabilitiesRouter.get("/freebusy", async (request, response) => {
+    const { day, month, year } = request.query;
+    const duration = Number(request.query.duration);
+    const user = await User.findById(request.query.user);
+
     const oauth2Client = new google.auth.OAuth2({
         clientID: process.env.GOOGLE_CLIENT_ID,
         clientSecret: process.env.GOOGLE_CLIENT_SECRET,
@@ -14,15 +16,12 @@ availabilitiesRouter.get("/freebusy", (request, response) => {
     });
 
     oauth2Client.credentials = {
-        access_token: request.user.accessToken,
-        refresh_token: request.user.refreshToken
+        access_token: user.accessToken,
+        refresh_token: user.refreshToken
     }; 
 
-    const availStartTime = new Date(2020, 11, 12, 9, 0, 0, 0);
-    const availEndTime = new Date(2020, 11, 12, 17, 0, 0, 0);
-
-    // Duration in minutes
-    const duration = 60;
+    const availStartTime = new Date(year, month, day, 9, 0, 0, 0);
+    const availEndTime = new Date(year, month, day, 17, 0, 0, 0);
 
 
     const calendar = google.calendar({ version: "v3", auth: oauth2Client });


### PR DESCRIPTION
### What it Does:
* upon request to back-end freebusy controller, the front-end renders a list of available timeslot buttons or a "no availability" message depending on if there are available timeslots

**When there is Availability**:
![image](https://user-images.githubusercontent.com/28552357/102022744-d3832080-3d56-11eb-9805-ad97e819030c.png)

**When There Isn't**:
![image](https://user-images.githubusercontent.com/28552357/102022756-eac20e00-3d56-11eb-83a3-40090e64a07e.png)

* selected day on calendar defaults to tomorrows date upon render

### What to Look For:
* DRY code
* efficient code sequence of steps to retrieve and display timeslots

### What To Avoid
* access tokens not being refreshed after 1 hr (will look at this in another PR)